### PR TITLE
docs(ci): Auto-git commits now match lintcommit

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Push Changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "Auto-generate Vimdoc"
+          commit_message: "docs(vimdoc): Auto-generate user / API documentation + vimtags"
           commit_user_name: "github-actions[bot]"
           commit_user_email: "github-actions[bot]@users.noreply.github.com"
           commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ busted --helper spec/minimal_init.lua . --tags=simple
 # Tracking Updates
 See [doc/news.txt](doc/news.txt) for updates.
 
-You can add changes to this plugin by adding this URL to your RSS feed:
+You can watch this plugin for changes by adding this URL to your RSS feed:
 ```
 https://github.com/ColinKennedy/nvim-best-practices-plugin-template/commits/main/doc/news.txt.atom
 ```


### PR DESCRIPTION
The documentation.yml did not use foo(bar): Message format