### PR TITLE
Making LuaLS correctly detect all the entities

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,10 +1,22 @@
 {
-    "diagnostics.globals": [
-        "vim"
-    ],
     "diagnostics.libraryFiles": "Disable",
     "runtime.version": "LuaJIT",
     "workspace.checkThirdParty": "Disable",
-    "workspace.library": ["$PWD/.dependencies"]
+    "workspace.library": [
+        "$PWD/.dependencies",
+        "${3rd}/busted/library",
+        "${3rd}/luv/library",
+        "${3rd}/luassert/library",
+        "$VIMRUNTIME/lua",
+        "lua",
+    ],
+    "runtime.path": [
+        "lua",
+        "lua/?.lua",
+        "lua/?/init.lua",
+        "?.lua",
+        "?/init.lua",
+        "$XDG_DATA_HOME/nvim/lazy",
+      ]
 }
 


### PR DESCRIPTION
Removing diagnostics section made LSP
to see all the fields inside of vim.

Additional entries in luarc make LSP detect all entities from busted and luassert library.

For some reason it did not work out of the box in my environment.