### PR TITLE
chore(test): Removed old dependency

### DIFF
--- a/plugin-template-scm-1.rockspec
+++ b/plugin-template-scm-1.rockspec
@@ -15,7 +15,6 @@ test_dependencies = {
     "busted >= 2.0, < 3.0",
     "lua >= 5.1, < 6.0",
     "nlua >= 0.2, < 1.0",
-    "nui.nvim >= 0.2, < 1.0",
 }
 
 -- Reference: https://github.com/luarocks/luarocks/wiki/test#test-types


### PR DESCRIPTION
nui.nvim was copy-pasted. I don't think it needs to be here