### PR TITLE
fix(luals): Added missing diagnostics paths

### DIFF
--- a/.github/workflows/.luarc.json
+++ b/.github/workflows/.luarc.json
@@ -1,10 +1,13 @@
 {
-    "diagnostics.globals": [
-        "vim"
-    ],
     "diagnostics.libraryFiles": "Disable",
     "runtime.version": "LuaJIT",
     "workspace.checkThirdParty": "Disable",
     "workspace.ignoreDir": [".lua", ".luarocks"],
-    "workspace.library": ["$PWD/.dependencies"]
+    "workspace.library": [
+        "$PWD/.dependencies/busted/library",
+        "$PWD/.dependencies/luassert/library",
+        "$PWD/.dependencies/luvit-meta/library",
+        "$VIMRUNTIME/lua",
+        "lua"
+    ]
 }

--- a/.github/workflows/llscheck.yml
+++ b/.github/workflows/llscheck.yml
@@ -22,6 +22,13 @@ jobs:
     - name: Update Submodules
       run: git submodule update --init --recursive
 
+    - uses: rhysd/action-setup-vim@v1
+      # NOTE: We need Neovim installed in order to expose the $VIMRUNTIME
+      # environment variable
+      with:
+        neovim: true
+        version: stable
+
     - uses: leafo/gh-actions-lua@v10
       with:
         # Neovim is compiled with LuaJIT so we might as well match. But it
@@ -45,4 +52,4 @@ jobs:
 
     - name: test
       run: |
-        llscheck --configpath .github/workflows/.luarc.json .
+        VIMRUNTIME=`nvim -l scripts/print_vimruntime_environment_variable.lua` llscheck --configpath .github/workflows/.luarc.json .

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule ".dependencies/luassert"]
 	path = .dependencies/luassert
 	url = git@github.com:LuaCATS/luassert.git
+[submodule ".dependencies/luvit-meta"]
+	path = .dependencies/luvit-meta
+	url = git@github.com:Bilal2453/luvit-meta.git

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,10 +1,12 @@
 {
-    "diagnostics.globals": [
-        "vim"
-    ],
     "diagnostics.libraryFiles": "Disable",
     "runtime.version": "LuaJIT",
     "workspace.checkThirdParty": "Disable",
-    "workspace.library": ["$PWD/.dependencies"]
+    "workspace.library": [
+        "$PWD/.dependencies/busted/library",
+        "$PWD/.dependencies/luassert/library",
+        "$PWD/.dependencies/luvit-meta/library",
+        "$VIMRUNTIME/lua",
+        "lua"
+    ]
 }
-

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ api_documentation:
 	nvim -u scripts/make_api_documentation/minimal_init.lua -l scripts/make_api_documentation/main.lua
 
 llscheck:
-	llscheck --configpath .luarc.json .
+	VIMRUNTIME=`nvim -l scripts/print_vimruntime_environment_variable.lua` llscheck --configpath .luarc.json .
 
 luacheck:
 	luacheck lua plugin scripts spec

--- a/lua/plugin_template/_cli/cli_subcommand.lua
+++ b/lua/plugin_template/_cli/cli_subcommand.lua
@@ -362,9 +362,7 @@ function M.make_subcommand_triager(subcommands)
         end
 
         if subcommand.run then
-            subcommand.run(vim.tbl_deep_extend("force", opts, {
-                input = argparse.parse_arguments(stripped_text),
-            }))
+            subcommand.run(vim.tbl_deep_extend("keep", { input = argparse.parse_arguments(stripped_text) }, opts))
 
             return
         end

--- a/lua/plugin_template/_cli/cmdparse/init.lua
+++ b/lua/plugin_template/_cli/cmdparse/init.lua
@@ -960,7 +960,7 @@ end
 --- If the parser is a child of a subparser then this instance must be given
 --- a name via `{name="foo"}` or this function will error.
 ---
----@param options cmdparse.ParameterParserOptions
+---@param options cmdparse.ParameterParserInputOptions | cmdparse.ParameterParserOptions
 ---    The options that we might pass to `cmdparse.ParameterParser.new`.
 ---@return cmdparse.ParameterParser
 ---    The created instance.
@@ -971,6 +971,7 @@ function M.ParameterParser.new(options)
     end
 
     if options.parent then
+        ---@cast options cmdparse.ParameterParserOptions
         types_input.validate_name(options)
     end
 

--- a/lua/plugin_template/_commands/copy_logs/runner.lua
+++ b/lua/plugin_template/_commands/copy_logs/runner.lua
@@ -32,13 +32,28 @@ end
 function M._read_file(path, callback)
     -- NOTE: mode 428 == rw-rw-rw-
     vim.uv.fs_open(path, "r", 438, function(error_open, handler)
-        assert(not error_open, error_open)
+        if error_open then
+            error(error_open)
+        end
+        if not handler then
+            error(string.format('Path "%s" could not be opened.', path))
+        end
 
         vim.uv.fs_fstat(handler, function(error_stat, stat)
-            assert(not error_stat, error_stat)
+            if error_stat then
+                error(error_stat)
+            end
+            if not stat then
+                error(string.format('Path "%s" could not be stat-ed.', path))
+            end
 
             vim.uv.fs_read(handler, stat.size, 0, function(error_read, data)
-                assert(not error_read, error_read)
+                if error_read then
+                    error(error_read)
+                end
+                if not data then
+                    error(string.format('Path "%s" could no be read for data.', path))
+                end
 
                 vim.uv.fs_close(handler, function(error_close)
                     assert(not error_close, error_close)

--- a/lua/plugin_template/health.lua
+++ b/lua/plugin_template/health.lua
@@ -86,6 +86,11 @@ local function _append_validated(array, name, value_creator, expected, message)
 
     local validated
     success, validated = pcall(vim.validate, {
+        -- TODO: I think the Neovim type annotation is wrong. Once Neovim
+        -- 0.10 is dropped let's just change this over to the new
+        -- vim.validate signature.
+        --
+        ---@diagnostic disable-next-line: assign-type-mismatch
         [name] = { value, expected, message },
     })
 
@@ -112,6 +117,11 @@ local function _get_boolean_issue(key, data)
 
                 return type(value) == "boolean"
             end,
+            -- TODO: I think the Neovim type annotation is wrong. Once Neovim
+            -- 0.10 is dropped let's just change this over to the new
+            -- vim.validate signature.
+            --
+            ---@diagnostic disable-next-line: assign-type-mismatch
             "a boolean",
         },
     })

--- a/scripts/print_vimruntime_environment_variable.lua
+++ b/scripts/print_vimruntime_environment_variable.lua
@@ -1,0 +1,1 @@
+io.write(vim.fn.expand("$VIMRUNTIME"))

--- a/spec/test_utilities/mock_test.lua
+++ b/spec/test_utilities/mock_test.lua
@@ -34,6 +34,7 @@ end
 
 --- Make it so no existing API calls or commands print text.
 function M.silence_all_internal_prints()
+    ---@diagnostic disable-next-line: duplicate-set-field
     vim.notify = function(...) end -- luacheck: ignore 212
 end
 


### PR DESCRIPTION
A continuation of https://github.com/ColinKennedy/nvim-best-practices-plugin-template/pull/17

Added `luvit-meta/library` so that we get proper `vim.uv.*` diagnostics. That also opened up a bunch of errors that went unsolved.

LSP diagnostics should be working as expected, both interactively in Neovim + in the PR CI.

The `"diagnostics.globals": ["vim"]` line, which was preventing auto-complete among other things, has been removed 