### PR TITLE
ci(busted): simplified how busted gets called

### DIFF
--- a/.busted
+++ b/.busted
@@ -5,6 +5,7 @@ return {
     lua = "nlua",
   },
   default = {
+    helper = "./spec/minimal_init.lua",
     verbose = true,
   },
   tests = {

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ stylua:
 	stylua lua plugin scripts spec
 
 test: clone_git_dependencies
-	busted --helper spec/minimal_init.lua .
+	busted .

--- a/README.md
+++ b/README.md
@@ -218,9 +218,10 @@ eval $(luarocks path --lua-version 5.1 --bin)
 ## Running
 Run all tests
 ```sh
+# Using the package manager
 luarocks test --test-type busted
 # Or manually
-busted --helper spec/minimal_init.lua .
+busted .
 # Or with Make
 make test
 ```


### PR DESCRIPTION
Don't hard-code `--helper spec/minimal_init.lua` anywhere anymore