### PR TITLE
ci(misc): moved logic to be more CLI-driven

### DIFF
--- a/.github/workflows/llscheck.yml
+++ b/.github/workflows/llscheck.yml
@@ -82,4 +82,4 @@ jobs:
 
     - name: Test
       run: |
-        VIMRUNTIME=`nlua -e 'io.write(os.getenv("VIMRUNTIME"))'` llscheck --configpath .github/workflows/.luarc.json .
+        make llscheck CONFIGURATION=.github/workflows/.luarc.json

--- a/.github/workflows/stylua.yml
+++ b/.github/workflows/stylua.yml
@@ -14,8 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: JohnnyMorganz/stylua-action@v4
+
+      # TODO: Change this once an outcome for this PR is done
+      #
+      # Reference: https://github.com/JohnnyMorganz/stylua-action/pull/58
+      #
+      - uses: ColinKennedy/stylua-action@remove_exec_test
         with:
           version: latest
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --color always --check lua plugin spec
+          args: false
+
+      - name: Run stylua
+        run: |
+          make check-stylua

--- a/.github/workflows/urlchecker.yml
+++ b/.github/workflows/urlchecker.yml
@@ -1,4 +1,4 @@
-# TODO: (you) Make sure to update your file_types below to whatever makes sense for you.
+# TODO: (you) Make sure to update your file types below to whatever makes sense for you.
 
 name: URLChecker
 
@@ -18,53 +18,98 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: urlcheck - doc directory
-      uses: urlstechie/urlchecker-action@master
-      with:
-        subfolder: doc
-        file_types: .json,.lua,.md,.txt,.vim,.yml
+    - name: Install urlchecker
+      run: |
+        python -m pip install urlchecker
 
-    - name: urlcheck - lua directory
-      uses: urlstechie/urlchecker-action@master
-      with:
-        subfolder: lua
-        file_types: .json,.lua,.md,.txt,.vim,.yml
+    - name: "Directory: doc"
+      run: |
+        urlchecker check \
+          --branch main \
+          --subfolder doc \
+          --no-print \
+          --file-types .json,.lua,.md,.txt,.vim,.yml \
+          --retry-count 1 \
+          --timeout 5 \
+          .
 
-    - name: urlcheck - plugin directory
-      uses: urlstechie/urlchecker-action@master
-      with:
-        subfolder: plugin
-        file_types: .json,.lua,.md,.txt,.vim,.yml
+    - name: "Directory: lua"
+      run: |
+        urlchecker check \
+          --branch main \
+          --subfolder lua \
+          --no-print \
+          --file-types .json,.lua,.md,.txt,.vim,.yml \
+          --retry-count 1 \
+          --timeout 5 \
+          .
 
-    - name: urlcheck - scripts directory
-      uses: urlstechie/urlchecker-action@master
-      with:
-        subfolder: scripts
-        file_types: .json,.lua,.md,.txt,.vim,.yml
+    - name: "Directory: plugin"
+      run: |
+        urlchecker check \
+          --branch main \
+          --subfolder plugin \
+          --no-print \
+          --file-types .json,.lua,.md,.txt,.vim,.yml \
+          --retry-count 1 \
+          --timeout 5 \
+          .
 
-    - name: urlcheck - spec directory
-      uses: urlstechie/urlchecker-action@master
-      with:
-        subfolder: spec
-        file_types: .json,.lua,.md,.txt,.vim,.yml
+    - name: "Directory: scripts"
+      run: |
+        urlchecker check \
+          --branch main \
+          --subfolder scripts \
+          --no-print \
+          --file-types .json,.lua,.md,.txt,.vim,.yml \
+          --retry-count 1 \
+          --timeout 5 \
+          .
 
-    - name: urlcheck - CHANGELOG.md
-      uses: urlstechie/urlchecker-action@master
-      with:
-        exclude_patterns: https://github.com/ColinKennedy/nvim-best-practices-plugin-template/compare/v
-        subfolder: .
-        include_files: CHANGELOG.md
+    - name: "Directory: spec"
+      run: |
+        urlchecker check \
+          --branch main \
+          --subfolder scripts \
+          --no-print \
+          --file-types .json,.lua,.md,.txt,.vim,.yml \
+          --retry-count 1 \
+          --timeout 5 \
+          .
+
+    - name: "File: CHANGELOG.md"
       if: ${{ github.event.pull_request.head.ref == 'release-please--branches--main' }}
+      run: |
+        urlchecker check \
+          --branch main \
+          --subfolder . \
+          --exclude-patterns https://github.com/ColinKennedy/nvim-best-practices-plugin-template/compare/v
+          --files CHANGELOG.md \
+          --no-print \
+          --file-types .json,.lua,.md,.txt,.vim,.yml \
+          --retry-count 1 \
+          --timeout 5 \
+          .
 
-    - name: urlcheck - CHANGELOG.md
-      uses: urlstechie/urlchecker-action@master
-      with:
-        subfolder: .
-        include_files: CHANGELOG.md
+    - name: "File: CHANGELOG.md"
       if: ${{ github.event.pull_request.head.ref != 'release-please--branches--main' }}
+      run: |
+        urlchecker check \
+          --branch main \
+          --subfolder . \
+          --files CHANGELOG.md \
+          --no-print \
+          --retry-count 1 \
+          --timeout 5 \
+          .
 
-    - name: urlcheck - README.md
-      uses: urlstechie/urlchecker-action@master
-      with:
-        subfolder: .
-        include_files: README.md
+    - name: "File: README.md"
+      run: |
+        urlchecker check \
+          --branch main \
+          --subfolder . \
+          --files README.md \
+          --no-print \
+          --retry-count 1 \
+          --timeout 5 \
+          .

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ else
     IGNORE_EXISTING = 2> /dev/null || true
 endif
 
+CONFIGURATION = .luarc.json
+
 clone_git_dependencies:
 	git clone git@github.com:ColinKennedy/mega.cmdparse.git .dependencies/mega.cmdparse $(IGNORE_EXISTING)
 	git clone git@github.com:LuaCATS/busted.git .dependencies/busted $(IGNORE_EXISTING)
@@ -19,10 +21,13 @@ api_documentation:
 	nvim -u scripts/make_api_documentation/minimal_init.lua -l scripts/make_api_documentation/main.lua
 
 llscheck: clone_git_dependencies
-	VIMRUNTIME=`nlua -e 'io.write(os.getenv("VIMRUNTIME"))'` llscheck --configpath .luarc.json .
+	VIMRUNTIME=`nlua -e 'io.write(os.getenv("VIMRUNTIME"))'` llscheck --configpath $(CONFIGURATION) .
 
 luacheck:
 	luacheck lua plugin scripts spec
+
+check-stylua:
+	stylua lua plugin scripts spec --color always --check
 
 stylua:
 	stylua lua plugin scripts spec

--- a/doc/plugin-template.txt
+++ b/doc/plugin-template.txt
@@ -1,4 +1,4 @@
-*plugin-template.txt*     For Neovim >= 0.8.0    Last change: 2024 December 31
+*plugin-template.txt*     For Neovim >= 0.8.0     Last change: 2025 January 10
 
 ==============================================================================
 Table of Contents                          *plugin-template-table-of-contents*


### PR DESCRIPTION
The theme of this PR is the terminal. It changes CI commands to be more terminal based (less GitHub-action magic and more "stuff you can run yourself"). This PR is a trade-off though. `urlchecker.yml` is more larger now because of the duplication. But I think the trade-off and advantage of knowing what the code is really doing is well worth it.

llscheck and stylua checks now also reuse the Makefile, with minimal edits needed.