### PR TITLE
fix(rockspec): updated package name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,12 +51,12 @@ jobs:
       uses: ColinKennedy/luarocks-rockspec-expander@v1.0.0
       with:
         input: template.rockspec
-        output: plugin-template-scm-1.rockspec
+        output: nvim-best-practices-plugin-template-scm-1.rockspec
         delete_input_after: true
 
     - name: Build Test Dependencies
       run: |
-        luarocks test plugin-template-scm-1.rockspec --prepare
+        luarocks test nvim-best-practices-plugin-template-scm-1.rockspec --prepare
 
     - name: Test
       run: |

--- a/template.rockspec
+++ b/template.rockspec
@@ -11,7 +11,7 @@ local specrev = "$specrev"
 local repo_url = "$repo_url"
 
 rockspec_format = "3.0"
-package = "plugin-template"
+package = "nvim-best-practices-plugin-template"
 version = modrev .. "-" .. specrev
 
 local user = "ColinKennedy"


### PR DESCRIPTION
Releasing to luarocks failed - https://github.com/ColinKennedy/nvim-best-practices-plugin-template/actions/runs/12727492137/job/35477078267 due to a package name mismatch. I'm hoping this will fix it.