### PR TITLE
fix(rockspec): added missing lua dependencies

### DIFF
--- a/template.rockspec
+++ b/template.rockspec
@@ -23,6 +23,15 @@ description = {
     summary = 'A "Best Practices" Neovim plugin template',
 }
 
+dependencies = {
+    "mega.cmdparse >= 1.0.3, < 2.0",
+    "mega.logging >= 1.1.4, < 2.0",
+
+    -- TODO(you): Remove these dependencies if you don't need them
+    "lualine.nvim", -- Reference: https://luarocks.org/modules/neorocks/lualine.nvim
+    "telescope.nvim >= 0.1.8 < 1.0",
+}
+
 test_dependencies = {
     "busted >= 2.0, < 3.0",
     "lua >= 5.1, < 6.0",


### PR DESCRIPTION
Now that the rockspec is replicating on luarocks correctly ([example](https://luarocks.org/manifests/colinkennedy/nvim-best-practices-plugin-template-1.5.3-1.rockspec)) it's time to add any missing data.

It looks like only direct dependencies were missing