### PR TITLE
ci(llscheck): "simplify git repository cloning" logic

### DIFF
--- a/.github/workflows/llscheck.yml
+++ b/.github/workflows/llscheck.yml
@@ -51,40 +51,17 @@ jobs:
         luarocks install llscheck
         luarocks install nlua
 
-    - name: Clone Dependencies - busted
-      uses: actions/checkout@v4
-      with:
-        repository: "LuaCATS/busted"
-        path: ".dependencies/busted"
-
-    - name: Clone Dependencies - luassert
-      uses: actions/checkout@v4
-      with:
-        repository: "LuaCATS/luassert"
-        path: ".dependencies/luassert"
-
-    - name: Clone Dependencies - luavit-meta
-      uses: actions/checkout@v4
-      with:
-        repository: "Bilal2453/luvit-meta"
-        path: ".dependencies/luvit-meta"
-
-    - name: Clone Dependencies - mega.cmdparse
-      uses: actions/checkout@v4
-      with:
-        repository: "ColinKennedy/mega.cmdparse"
-        path: ".dependencies/mega.cmdparse"
-
-    - name: Clone Dependencies - mega.logging
-      uses: actions/checkout@v4
-      with:
-        repository: "ColinKennedy/mega.logging"
-        path: ".dependencies/mega.logging"
-
     - name: Print Version
       run: |
         lua-language-server --version
 
     - name: Test
       run: |
+        # We use SSH in the `Makefile` but GitHub actions don't allow that. So
+        # we force git to clone using HTTP instead.
+        #
+        export GIT_CONFIG=~/.gitconfig
+        git config url."https://github.com/".insteadOf git@github.com:
+
+        # Now do the llscheck (and any git clones, as needed)
         make llscheck CONFIGURATION=.github/workflows/.luarc.json

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,11 @@ endif
 CONFIGURATION = .luarc.json
 
 clone_git_dependencies:
+	git clone git@github.com:Bilal2453/luvit-meta.git .dependencies/luvit-meta $(IGNORE_EXISTING)
 	git clone git@github.com:ColinKennedy/mega.cmdparse.git .dependencies/mega.cmdparse $(IGNORE_EXISTING)
+	git clone git@github.com:ColinKennedy/mega.logging.git .dependencies/mega.logging $(IGNORE_EXISTING)
 	git clone git@github.com:LuaCATS/busted.git .dependencies/busted $(IGNORE_EXISTING)
 	git clone git@github.com:LuaCATS/luassert.git .dependencies/luassert $(IGNORE_EXISTING)
-	git clone git@github.com:Bilal2453/luvit-meta.git .dependencies/luvit-meta $(IGNORE_EXISTING)
 
 api_documentation:
 	nvim -u scripts/make_api_documentation/minimal_init.lua -l scripts/make_api_documentation/main.lua


### PR DESCRIPTION
The hard-coding in llscheck.yml was never optimal. This PR should make things simpler.

There's a "Convert SSH to HTTP so we can clone over GitHub actions" trick that I don't feel great about. The easiest thing would be to just replace the SSH clones in the `Makefile` to be HTTP clones but I'd like to keep SSH to promote better security. In the future that might happen. For now this is still an improvement over what exists.

Now, the `Makefile` is the single source of truth for cloning across all GitHub workflow actions