### PR TITLE
ci(dependencies): removed nlua as a required dependency

### DIFF
--- a/.github/workflows/llscheck.yml
+++ b/.github/workflows/llscheck.yml
@@ -49,7 +49,6 @@ jobs:
     - name: Install llscheck
       run: |
         luarocks install llscheck
-        luarocks install nlua
 
     - name: Print Version
       run: |

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ api_documentation:
 	nvim -u scripts/make_api_documentation/minimal_init.lua -l scripts/make_api_documentation/main.lua
 
 llscheck: clone_git_dependencies
-	VIMRUNTIME=`nlua -e 'io.write(os.getenv("VIMRUNTIME"))'` llscheck --configpath $(CONFIGURATION) .
+	VIMRUNTIME="`nvim --clean --headless --cmd 'lua io.write(os.getenv("VIMRUNTIME"))' --cmd 'quit'`" llscheck --configpath $(CONFIGURATION) .
 
 luacheck:
 	luacheck lua plugin scripts spec

--- a/template.rockspec
+++ b/template.rockspec
@@ -35,7 +35,6 @@ dependencies = {
 test_dependencies = {
     "busted >= 2.0, < 3.0",
     "lua >= 5.1, < 6.0",
-    "nlua >= 0.2, < 1.0",
 }
 
 -- Reference: https://github.com/luarocks/luarocks/wiki/test#test-types


### PR DESCRIPTION
`nlua` isn't actually needed. Let's remove it to be more minimal.