### PR TITLE
ci(html): improved automated HTML gh-pages generation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,38 +39,16 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: emmylua_doc_cli
-          version: '^0.4.4'
-
-      - name: Save File index.md
-        if: hashFiles('markdown/docs/index.md') != ''
-        run: |
-          temp_file=`mktemp`
-          echo "index_temporary_path=$temp_file" >> $GITHUB_ENV
-          cp markdown/docs/index.md $temp_file
-
-      - name: Save File mkdocs.yml
-        if: hashFiles('markdown/mkdocs.yml') != ''
-        run: |
-          temp_file=`mktemp`
-          echo "mkdocs_temporary_path=$temp_file" >> $GITHUB_ENV
-          cp markdown/mkdocs.yml $temp_file
+          version: '^0.4.7'
 
       - name: Generate Mkdocs Files With emmylua_doc_cli
-        run: emmylua_doc_cli --input lua/ --output markdown/
-
-      - name: Restore index.md
-        if: env.index_temporary_path != ''
-        run: cp $index_temporary_path markdown/docs/index.md
-
-      - name: Restore mkdocs.yml
-        if: env.mkdocs_temporary_path != ''
-        run: cp $mkdocs_temporary_path markdown/mkdocs.yml
+        run: emmylua_doc_cli --input lua/ --output markdown/generated --mixin markdown/manual
 
       - name: Deploy To GitHub Pages
         uses: mhausenblas/mkdocs-deploy-gh-pages@1.26
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONFIG_FILE: markdown/mkdocs.yml
+          CONFIG_FILE: markdown/generated/mkdocs.yml
 
 
   vim_documentation:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ A template repository used to create Neovim plugins.
 - Auto-release to [luarocks](https://luarocks.org) & [GitHub](https://github.com/ColinKennedy/nvim-best-practices-plugin-template/releases)
 - Automated user documentation (using [panvimdoc](https://github.com/kdheepak/panvimdoc))
 - Automated API documentation (using [mini.doc](https://github.com/echasnovski/mini.doc))
-- Automated HTML documentation using [emmylua_doc_cli](https://github.com/CppCXY/emmylua-analyzer-rust/tree/main/crates/emmylua_doc_cli) & [mkdocs-material](https://github.com/squidfunk/mkdocs-material)
+- Automated HTML documentation + self-publishing using [emmylua_doc_cli](https://github.com/CppCXY/emmylua-analyzer-rust/tree/main/crates/emmylua_doc_cli) & [mkdocs-material](https://github.com/squidfunk/mkdocs-material)
+    - Yes, this repository has a website! Check it out at [nvim-best-practices-plugin-template](https://colinkennedy.github.io/nvim-best-practices-plugin-template)!
 - Vimtags generation
 - Built-in Vim commands
 - A high quality command mode parser

--- a/doc/plugin-template.txt
+++ b/doc/plugin-template.txt
@@ -1,4 +1,4 @@
-*plugin-template.txt*     For Neovim >= 0.8.0    Last change: 2025 February 09
+*plugin-template.txt*     For Neovim >= 0.8.0    Last change: 2025 February 11
 
 ==============================================================================
 Table of Contents                          *plugin-template-table-of-contents*

--- a/doc/plugin_template_api.txt
+++ b/doc/plugin_template_api.txt
@@ -13,7 +13,7 @@ package must get a new **major** version.
 Print the `names`.
 
 Parameters ~
-    {names} `(string[]?)` Some text to print out. e.g. `{"a", "b", "c"}`.
+    {names} `(string)`[]? Some text to print out. e.g. `{"a", "b", "c"}`.
 
 ------------------------------------------------------------------------------
                                                *plugin_template.run_copy_logs()*
@@ -23,7 +23,7 @@ Parameters ~
 Copy the log data from the given `path` to the user's clipboard.
 
 Parameters ~
-    {path} `(string?)`
+    {path} `(string)`?
        A path on-disk to look for logs. If none is given, the default fallback
        location is used instead.
 
@@ -35,11 +35,11 @@ Parameters ~
 Print `phrase` according to the other options.
 
 Parameters ~
-    {phrase} `(string[])`
+    {phrase} `(string)`[]
        The text to say.
-    {repeat_} `(number?)`
+    {repeat_} `(number)`?
        A 1-or-more value. The number of times to print `word`.
-    {style} `(string?)`
+    {style} `(string)`?
        Control how the text should be shown.
 
 ------------------------------------------------------------------------------
@@ -52,9 +52,9 @@ Print `phrase` according to the other options.
 Parameters ~
     {word} `(string)`
        The text to say.
-    {repeat_} `(number?)`
+    {repeat_} `(number)`?
        A 1-or-more value. The number of times to print `word`.
-    {style} `(string?)`
+    {style} `(string)`?
        Control how the text should be shown.
 
 ------------------------------------------------------------------------------
@@ -85,7 +85,7 @@ Parameters ~
 Print Zzz each `count`.
 
 Parameters ~
-    {count} `(number?)` Prints 1 Zzz per `count`. A value that is 1-or-greater.
+    {count} `(number)`? Prints 1 Zzz per `count`. A value that is 1-or-greater.
 
 
 WARNING: This file is auto-generated. Do not edit it!

--- a/doc/plugin_template_types.txt
+++ b/doc/plugin_template_types.txt
@@ -10,11 +10,11 @@ operation of this Lua plugin.
    The user's customizations for this plugin.
 
 Fields ~
-    {commands} plugin_template.ConfigurationCommands?
+    {commands} |plugin_template.ConfigurationCommands|?
        Customize the fallback behavior of all `:PluginTemplate` commands.
-    {logging} plugin_template.LoggingConfiguration?
+    {logging} |plugin_template.LoggingConfiguration|?
        Control how and which logs print to file / Neovim.
-    {tools} plugin_template.ConfigurationTools?
+    {tools} |plugin_template.ConfigurationTools|?
        Optional third-party tool integrations.
 
 ------------------------------------------------------------------------------
@@ -22,9 +22,9 @@ Fields ~
    Customize the fallback behavior of all `:PluginTemplate` commands.
 
 Fields ~
-    {goodnight_moon} plugin_template.ConfigurationGoodnightMoon?
+    {goodnight_moon} |plugin_template.ConfigurationGoodnightMoon|?
        The default values when a user calls `:PluginTemplate goodnight-moon`.
-    {hello_world} plugin_template.ConfigurationHelloWorld?
+    {hello_world} |plugin_template.ConfigurationHelloWorld|?
        The default values when a user calls `:PluginTemplate hello-world`.
 
 ------------------------------------------------------------------------------
@@ -32,7 +32,7 @@ Fields ~
    The default values when a user calls `:PluginTemplate goodnight-moon`.
 
 Fields ~
-    {read} plugin_template.ConfigurationGoodnightMoonRead?
+    {read} |plugin_template.ConfigurationGoodnightMoonRead|?
        The default values when a user calls `:PluginTemplate goodnight-moon read`.
 
 ------------------------------------------------------------------------------
@@ -52,12 +52,12 @@ Fields ~
        | vim.log.levels.TRACE
        | vim.log.levels.WARN)?
        Any messages above this level will be logged.
-    {use_console} `(boolean?)`
+    {use_console} `(boolean)`?
        Should print the output to neovim while running. Warning: This is very
        spammy. You probably don't want to enable this unless you have to.
-    {use_file} `(boolean?)`
+    {use_file} `(boolean)`?
        Should write to a file.
-    {output_path} `(string?)`
+    {output_path} `(string)`?
        The default path on-disk where log files will be written to.
        Defaults to "/home/selecaoone/.local/share/nvim/plugin_name.log".
 
@@ -74,7 +74,7 @@ Fields ~
    The default values when a user calls `:PluginTemplate hello-world`.
 
 Fields ~
-    {say} plugin_template.ConfigurationHelloWorldSay?
+    {say} |plugin_template.ConfigurationHelloWorldSay|?
        The default values when a user calls `:PluginTemplate hello-world say`.
 
 ------------------------------------------------------------------------------
@@ -93,7 +93,7 @@ Fields ~
    Optional third-party tool integrations.
 
 Fields ~
-    {lualine} plugin_template.ConfigurationToolsLualine?
+    {lualine} |plugin_template.ConfigurationToolsLualine|?
        A Vim statusline replacement that will show the command that the user just ran.
 
 ------------------------------------------------------------------------------
@@ -102,9 +102,9 @@ Fields ~
    command runs.
 
 Fields ~
-    {color} vim.api.keyset.highlight?
+    {color} |vim.api.keyset.highlight|?
        The foreground/background color to use for the Lualine status.
-    {prefix} `(string?)`
+    {prefix} `(string)`?
        The text to display in lualine.
 
 

--- a/markdown/manual/docs/index.md
+++ b/markdown/manual/docs/index.md
@@ -1,0 +1,4 @@
+This website was generated automatically using
+a fancy Lua -> Markdown -> HTML translator. See
+[nvim-best-practices-plugin-template](https://github.com/ColinKennedy/nvim-best-practice
+s-plugin-template) for details!

--- a/spec/minimal_init.lua
+++ b/spec/minimal_init.lua
@@ -3,7 +3,6 @@
 local _PLUGINS = {
     ["https://github.com/nvim-lualine/lualine.nvim"] = os.getenv("LUALINE_DIR") or "/tmp/lualine.nvim",
     ["https://github.com/nvim-telescope/telescope.nvim"] = os.getenv("TELESCOPE_DIR") or "/tmp/telescope.nvim",
-    ["https://github.com/nvim-lua/plenary.nvim"] = os.getenv("PLENARY_DIR") or "/tmp/plenary.nvim",
     ["https://github.com/ColinKennedy/mega.cmdparse"] = os.getenv("MEGA_CMDPARSE_DIR") or "/tmp/mega.cmdparse",
     ["https://github.com/ColinKennedy/mega.logging"] = os.getenv("MEGA_LOGGING_DIR") or "/tmp/mega.logging",
 }
@@ -29,8 +28,6 @@ end
 vim.opt.rtp:append(".")
 
 vim.cmd("runtime plugin/plugin_template.lua")
-
-vim.cmd("runtime plugin/plenary.vim")
 
 require("lualine").setup()
 


### PR DESCRIPTION
- Removed `plenary.vim`, an old, unnecessary dependency
- mega.vimdoc got some improvements to the .txt were changed here automatically
- the `emmylua_doc_cli` logic is simpler now that 0.4.7+ has been released